### PR TITLE
Add Functional RegisterPage

### DIFF
--- a/ui/lib/login/page/login_page.dart
+++ b/ui/lib/login/page/login_page.dart
@@ -3,11 +3,17 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:harmony/state/config/harmony_page.dart';
 import 'package:harmony/routing/widget/harmony_router_delegate.dart';
 
-import '../widget/login_form.dart';
+import '../widget/auth_form.dart';
 
 final String assetName = './Harmony.svg';
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends StatefulWidget {
+  @override
+  _LoginPageState createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _formKey = GlobalKey<FormState>();
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -22,9 +28,10 @@ class LoginPage extends StatelessWidget {
               semanticsLabel: 'Harmony Logo',
               fit: BoxFit.fill,
             ),
-            LoginForm(
+            AuthForm(
+              formKey: _formKey,
               onSubmit: () =>
-                  {AppRouteScope.of(context).selectedPage = HarmonyPage.server},
+                  AppRouteScope.of(context).selectedPage = HarmonyPage.server,
             ),
           ],
         ),

--- a/ui/lib/login/page/register_page.dart
+++ b/ui/lib/login/page/register_page.dart
@@ -1,13 +1,43 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:harmony/auth/auth.dart';
+import 'package:harmony/login/widget/custom_form_field.dart';
 import 'package:harmony/state/config/harmony_page.dart';
 import 'package:harmony/routing/widget/harmony_router_delegate.dart';
+import 'package:provider/provider.dart';
 
 import '../widget/login_form.dart';
+import '../strings.dart' as strings;
 
 final String assetName = './Harmony.svg';
 
-class LoginPage extends StatelessWidget {
+class RegisterPage extends StatefulWidget {
+  @override
+  _RegisterPageState createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  late TextEditingController passwordController;
+  late TextEditingController emailController;
+  late TextEditingController displayNameController;
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    passwordController = TextEditingController();
+    emailController = TextEditingController();
+    displayNameController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    passwordController.dispose();
+    emailController.dispose();
+    displayNameController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -22,13 +52,62 @@ class LoginPage extends StatelessWidget {
               semanticsLabel: 'Harmony Logo',
               fit: BoxFit.fill,
             ),
-            LoginForm(
-              onSubmit: () =>
-                  {AppRouteScope.of(context).selectedPage = HarmonyPage.server},
+            AuthForm(
+              formKey: _formKey,
+              onSubmit: _handleRegisterSubmit,
+              formFields: [
+                CustomFormField.email(controller: emailController),
+                CustomFormField.displayName(controller: displayNameController),
+                CustomFormField.password(
+                  controller: passwordController,
+                ),
+                CustomFormField.passwordConfirm(_verifyPassword),
+              ],
             ),
           ],
         ),
       ),
     );
+  }
+
+  String? _verifyPassword(String? passwordConfrimation) {
+    if (passwordConfrimation != null &&
+        passwordConfrimation == passwordController.text) return null;
+    print(passwordConfrimation);
+    return strings.loginFormConfirmPasswordError;
+  }
+
+  void _handleRegisterSubmit() async {
+    final routeScope = AppRouteScope.of(context);
+    final authService = context.read<AuthService>();
+
+    final email = emailController.text;
+    final password = passwordController.text;
+    final displayName = displayNameController.text;
+
+    final result = await authService.register(
+      email: email,
+      password: password,
+      displayName: displayName,
+    );
+
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null || !messenger.mounted) return;
+    if (!result) {
+      messenger.showSnackBar(SnackBar(content: Text('Error Signing up')));
+      return;
+    }
+
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          'Succesfully signed up as $email with display name $displayName',
+        ),
+      ),
+    );
+
+    await Future.delayed(const Duration(seconds: 2));
+    // If successful register
+    routeScope.selectedPage = HarmonyPage.server;
   }
 }

--- a/ui/lib/login/strings.dart
+++ b/ui/lib/login/strings.dart
@@ -1,7 +1,5 @@
-
 /// This file is used to store the constant strings for the login directory
 /// Naming convention is prefixed with directory name
-
 
 String get loginFormEmail => 'Email';
 String get loginFormEmailError => 'Invalid Email';
@@ -17,3 +15,5 @@ String get loginFormUsernameError => 'Username is not available';
 
 String get loginFormDisplayName => 'Display Name';
 String get loginFormDisplayNameError => 'Please enter a display name';
+
+String get loginFormPasswordConfirmationError => 'Passwords do not match';

--- a/ui/lib/login/widget/auth_form.dart
+++ b/ui/lib/login/widget/auth_form.dart
@@ -3,26 +3,16 @@ import 'package:h_spec/spec.dart';
 
 import 'custom_form_field.dart';
 
-class LoginForm extends StatefulWidget {
-  const LoginForm({
+class AuthForm extends StatelessWidget {
+  AuthForm({
+    required GlobalKey<FormState> formKey,
     required this.onSubmit,
     this.formFields = const [],
-  });
+  }) : _formKey = formKey;
 
+  final VoidCallback onSubmit;
+  final GlobalKey<FormState> _formKey;
   final List<CustomFormField> formFields;
-
-  final Function onSubmit;
-  @override
-  LoginFormState createState() => LoginFormState(onSubmit: onSubmit);
-}
-
-class LoginFormState extends State<LoginForm> {
-  LoginFormState({
-    required this.onSubmit,
-  });
-
-  final Function onSubmit;
-  final _formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context) {
@@ -35,17 +25,11 @@ class LoginFormState extends State<LoginForm> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Container(
-                width: Sizing.loginFormWidth,
-                child: CustomFormField.email(),
-              ),
-              Container(
-                width: Sizing.loginFormWidth,
-                child: CustomFormField.password(),
-              ),
+              ...formFields.map(_buildFormField),
               ElevatedButton(
                 onPressed: () {
                   if (_formKey.currentState!.validate()) {
+                    _formKey.currentState!.save();
                     onSubmit();
                   }
                 },
@@ -55,6 +39,13 @@ class LoginFormState extends State<LoginForm> {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildFormField(CustomFormField formField) {
+    return Container(
+      width: Sizing.loginFormWidth,
+      child: formField,
     );
   }
 }

--- a/ui/lib/login/widget/custom_form_field.dart
+++ b/ui/lib/login/widget/custom_form_field.dart
@@ -10,12 +10,14 @@ class CustomFormField extends StatelessWidget {
   const CustomFormField._({
     required this.labelText,
     required this.validator,
+    this.controller,
     this.obscureText: false,
     this.enableSuggestions: true,
-    this.controller,
   });
 
-  factory CustomFormField.email() => CustomFormField._(
+  factory CustomFormField.email({required TextEditingController controller}) =>
+      CustomFormField._(
+        controller: controller,
         labelText: loginFormEmail,
         validator: (String? value) {
           return (value != null && _emailValidator.hasMatch(value)
@@ -24,8 +26,12 @@ class CustomFormField extends StatelessWidget {
         },
       );
 
-  factory CustomFormField.password() => CustomFormField._(
+  factory CustomFormField.password({
+    required TextEditingController controller,
+  }) =>
+      CustomFormField._(
         labelText: loginFormPassword,
+        controller: controller,
         validator: (String? value) {
           return (value != null && value.length >= 8
               ? null
@@ -39,21 +45,30 @@ class CustomFormField extends StatelessWidget {
         validator: validator,
       );
 
-  factory CustomFormField.username() => CustomFormField._(
+  factory CustomFormField.username({
+    required TextEditingController controller,
+  }) =>
+      CustomFormField._(
+        controller: controller,
         labelText: loginFormUsername,
         validator: (String? value) {
+          // I think we should opaquely send the username here and let the db
+          // error out if the username doesn't exist. We can update with an
+          // error later. Also, isn't email address our standin for username?
           return (/*check db for username*/ true
               ? null
               : loginFormUsernameError);
         },
       );
 
-  factory CustomFormField.displayName() => CustomFormField._(
+  factory CustomFormField.displayName({
+    required TextEditingController controller,
+  }) =>
+      CustomFormField._(
+        controller: controller,
         labelText: loginFormDisplayName,
         validator: (String? value) {
-          return (value != null
-              ? null
-              : loginFormDisplayNameError);
+          return (value != null ? null : loginFormDisplayNameError);
         },
       );
 

--- a/ui/lib/routing/config/harmony_route_information_parser.dart
+++ b/ui/lib/routing/config/harmony_route_information_parser.dart
@@ -14,6 +14,14 @@ import 'package:harmony/routing/config/harmony_route_path.dart';
 /// should display a page where the user learns about the app and has a way to
 /// authenticate.
 ///
+/// '/login' =>
+/// should display a page where the user can enter their credentials to
+/// authenticate themselves to use the app
+///
+/// '/register' =>
+/// should display a page where the user can enter required credentials to
+/// register themselves as an authenticated app user
+///
 /// '/server/$serverId/?$cchannelId' =>
 ///  should display a server page, this route can optionally contain a channelId
 ///  to display a selected channel within the server
@@ -32,7 +40,15 @@ class HarmonyRouteInformationParser
     // TODO(#31): Attempt user Authentication at this junction?
     final loggedIn = await authService.loggedIn;
     if (!loggedIn && segments.length == 1 && segments.first == 'welcome') {
-      return SynchronousFuture(WelcomeRotuePath());
+      return SynchronousFuture(WelcomeRoutePath());
+    }
+
+    if (!loggedIn && segments.length == 1 && segments.first == 'login') {
+      return SynchronousFuture(LoginRoutePath());
+    }
+
+    if (!loggedIn && segments.length == 1 && segments.first == 'register') {
+      return SynchronousFuture(RegisterRoutePath());
     }
 
     if (segments.contains('server')) {
@@ -40,7 +56,7 @@ class HarmonyRouteInformationParser
       return SynchronousFuture(AppShellRoutePath(serverId));
     }
 
-    return Future.value(UnknownRoutePath());
+    return SynchronousFuture(UnknownRoutePath());
   }
 
   @override
@@ -48,8 +64,16 @@ class HarmonyRouteInformationParser
     if (configuration is UnknownRoutePath)
       return RouteInformation(location: '/woops');
 
-    if (configuration is WelcomeRotuePath || configuration is SplashRoutePath) {
+    if (configuration is WelcomeRoutePath || configuration is SplashRoutePath) {
       return RouteInformation(location: '/welcome');
+    }
+
+    if (configuration is LoginRoutePath) {
+      return RouteInformation(location: '/login');
+    }
+
+    if (configuration is RegisterRoutePath) {
+      return RouteInformation(location: '/register');
     }
 
     if (configuration is AppShellRoutePath) {

--- a/ui/lib/routing/config/harmony_route_path.dart
+++ b/ui/lib/routing/config/harmony_route_path.dart
@@ -4,7 +4,7 @@ abstract class HarmonyRoutePath {
 
 class SplashRoutePath extends HarmonyRoutePath {}
 
-class WelcomeRotuePath extends HarmonyRoutePath {}
+class WelcomeRoutePath extends HarmonyRoutePath {}
 
 class AppShellRoutePath extends HarmonyRoutePath {
   const AppShellRoutePath(this.serverId);
@@ -12,3 +12,7 @@ class AppShellRoutePath extends HarmonyRoutePath {
 }
 
 class UnknownRoutePath extends HarmonyRoutePath {}
+
+class LoginRoutePath extends HarmonyRoutePath {}
+
+class RegisterRoutePath extends HarmonyRoutePath {}

--- a/ui/lib/routing/widget/harmony_router_delegate.dart
+++ b/ui/lib/routing/widget/harmony_router_delegate.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:harmony/app_shell/app_shell.dart';
+import 'package:harmony/login/page/register_page.dart';
 import 'package:harmony/splash/splash.dart';
 import 'package:harmony/login/login.dart';
 import 'package:harmony/state/state.dart';
@@ -10,8 +11,10 @@ import '../config/harmony_route_path.dart';
 
 final pageToPathMap = <HarmonyPage, HarmonyRoutePath>{
   HarmonyPage.unknown: UnknownRoutePath(),
-  HarmonyPage.welcome: WelcomeRotuePath(),
+  HarmonyPage.welcome: WelcomeRoutePath(),
   HarmonyPage.splash: SplashRoutePath(),
+  HarmonyPage.login: LoginRoutePath(),
+  HarmonyPage.register: RegisterRoutePath(),
 };
 
 class HarmonyRouterDelegate extends RouterDelegate<HarmonyRoutePath>
@@ -74,6 +77,10 @@ class HarmonyRouterDelegate extends RouterDelegate<HarmonyRoutePath>
             MaterialPage(
               child: LoginPage(),
             ),
+          if (appState.selectedPage == HarmonyPage.register)
+            MaterialPage(
+              child: RegisterPage(),
+            ),
           if (appState.selectedPage == HarmonyPage.server)
             MaterialPage(
               child: AppShell(),
@@ -89,20 +96,13 @@ class HarmonyRouterDelegate extends RouterDelegate<HarmonyRoutePath>
 
   // Used to update Application state when provided with a RoutePath
   @override
-  Future<void> setNewRoutePath(HarmonyRoutePath configuration) {
-    if (configuration is UnknownRoutePath) {
-      appState.selectedPage = HarmonyPage.unknown;
-    }
-
-    if (configuration is SplashRoutePath) {
-      _setPage(HarmonyPage.splash);
-    }
-
-    if (configuration is WelcomeRotuePath) {
-      _setPage(HarmonyPage.welcome);
-    }
+  Future<void> setNewRoutePath(HarmonyRoutePath configuration) async {
+    if (configuration is UnknownRoutePath) _setPage(HarmonyPage.unknown);
+    if (configuration is SplashRoutePath) _setPage(HarmonyPage.splash);
+    if (configuration is WelcomeRoutePath) _setPage(HarmonyPage.welcome);
+    if (configuration is LoginRoutePath) _setPage(HarmonyPage.login);
+    if (configuration is RegisterRoutePath) _setPage(HarmonyPage.register);
     if (configuration is AppShellRoutePath) _setPage(HarmonyPage.server);
-    return Future.value(null);
   }
 
   void _setPage(HarmonyPage page) {

--- a/ui/lib/state/config/harmony_page.dart
+++ b/ui/lib/state/config/harmony_page.dart
@@ -2,6 +2,7 @@ enum HarmonyPage {
   splash,
   welcome,
   login,
+  register,
   server,
   unknown,
 }

--- a/ui/lib/welcome/page/welcome_page.dart
+++ b/ui/lib/welcome/page/welcome_page.dart
@@ -24,6 +24,13 @@ class WelcomePage extends StatelessWidget {
               appState.pushPage(HarmonyPage.login);
             },
           ),
+          ActionButton(
+            title: 'Register',
+            onPressed: () {
+              print('go to registration page');
+              appState.pushPage(HarmonyPage.register);
+            },
+          ),
         ],
       ),
       body: Center(

--- a/ui/test/harmony_route_information_parser_test.dart
+++ b/ui/test/harmony_route_information_parser_test.dart
@@ -41,7 +41,33 @@ void main() {
         final routePath = await _buildParser().parseRouteInformation(routeInfo);
 
         // Assert
-        expect(routePath, isA<WelcomeRotuePath>());
+        expect(routePath, isA<WelcomeRoutePath>());
+      });
+
+      test(
+          'returns LoginRoute for location with 1 segment and containing '
+          'welcome', () async {
+        // Arrange
+        final routeInfo = RouteInformation(location: '/login');
+
+        // Act
+        final routePath = await _buildParser().parseRouteInformation(routeInfo);
+
+        // Assert
+        expect(routePath, isA<LoginRoutePath>());
+      });
+
+      test(
+          'returns RegisterRoute for location with 1 segment and containing '
+          'welcome', () async {
+        // Arrange
+        final routeInfo = RouteInformation(location: '/register');
+
+        // Act
+        final routePath = await _buildParser().parseRouteInformation(routeInfo);
+
+        // Assert
+        expect(routePath, isA<RegisterRoutePath>());
       });
 
       test(
@@ -110,6 +136,28 @@ void main() {
         // Assert
         expect(routeInfo, isNotNull);
         expect(routeInfo!.location, '/woops');
+      });
+
+      test('returns information with /login location for LoginRoute', () {
+        // Arrange/Act
+        final routeInfo = _buildParser().restoreRouteInformation(
+          LoginRoutePath(),
+        );
+
+        // Assert
+        expect(routeInfo, isNotNull);
+        expect(routeInfo!.location, '/login');
+      });
+
+      test('returns information with /register location for RegisterRoute', () {
+        // Arrange/Act
+        final routeInfo = _buildParser().restoreRouteInformation(
+          RegisterRoutePath(),
+        );
+
+        // Assert
+        expect(routeInfo, isNotNull);
+        expect(routeInfo!.location, '/register');
       });
 
       test(


### PR DESCRIPTION
This change provides the register page to the RouterDelegate.

Renames LoginForm -> AuthForm to avoid confusion since it's used on the LoginPage and the RegisterPage. Refactors more CustomFormField constructors to accept TextEditingControllers so that the Client of AuthForm can extract the values of the entered FormFields. RegisterPage now utilizes the provided AuthService to register a user in the application.