### PR TITLE
Add dgraph authentication config

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -69,3 +69,5 @@ enum MemberType {
   member
   untrusted
 }
+
+# Dgraph.Authorization {"VerificationKey":"super-authkey","Header":"X-Harmony-App-Auth", "jwkurl":"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com", "Namespace":"sub","Algo":"RS256","Audience":["harmony-7bb0f"]}


### PR DESCRIPTION
This change adds authentication to the dgraph schema when a request is sent to the dgraph server. With this, we can start building the authorization.